### PR TITLE
Fix activityRowRead not scaled by correct number of rows

### DIFF
--- a/Inference_pytorch/NeuroSIM/ProcessingUnit.cpp
+++ b/Inference_pytorch/NeuroSIM/ProcessingUnit.cpp
@@ -617,7 +617,7 @@ vector<double> GetInputVector(const vector<vector<double> > &input, int numInput
 			numofreadrow += 0;
 		}
 	}
-	double totalnumRow = input.size();
+	double totalnumRow = param->numRowSubArray;
 	*(activityRowRead) = numofreadrow/totalnumRow;
 	return copy;
 	copy.clear();


### PR DESCRIPTION
Previously totalnumRow was set to the input size, which is incorrect with underutilized subarrays. Now set to the total subarray rows.